### PR TITLE
Update the registry of base images in Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM projects.registry.vmware.com/cnsi/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/src/Dockerfile.inspection
+++ b/src/Dockerfile.inspection
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o inspector main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM projects.registry.vmware.com/cnsi/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/inspector .
 USER 65532:65532

--- a/src/Dockerfile.inspection.local
+++ b/src/Dockerfile.inspection.local
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM projects.registry.vmware.com/cnsi/distroless/static:nonroot
 WORKDIR /
 COPY  bin/inspector .
 USER 65532:65532

--- a/src/config/default/manager_auth_proxy_patch.yaml
+++ b/src/config/default/manager_auth_proxy_patch.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: projects.registry.vmware.com/cnsi/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
For the convenience of developers who have GFW issues, change the registry of the base images in Dockerfile.