### PR TITLE
deploy should not need go environment

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -63,23 +63,23 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: manifests generate fmt vet ## Run tests.
+test: tidy manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
 ##@ Build
 
-build-manager: generate fmt vet ## Build manager binary.
+build-manager: tidy generate fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/manager main.go
 
-build-inspector: generate fmt vet ## Build inspector command.
+build-inspector: tidy generate fmt vet ## Build inspector command.
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o bin/inspector cmd/inspector/main.go
 
-build-kubebench: generate fmt vet ## Build inspector command.
+build-kubebench: tidy generate fmt vet ## Build inspector command.
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o bin/kubebench cmd/kubebench/main.go
 
-run: manifests generate fmt vet ## Run a controller from your host.
+run: tidy manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build-all: docker-build-manager docker-build-inspector docker-build-kubebench docker-build-portal
@@ -138,7 +138,7 @@ portal:
 
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-controller-gen: tidy ## Download controller-gen locally if necessary.
+controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize

--- a/src/config/samples/goharbor_v1alpha1_inspectionpolicy.yaml
+++ b/src/config/samples/goharbor_v1alpha1_inspectionpolicy.yaml
@@ -15,7 +15,7 @@ spec:
     concurrencyRule: "Forbid"
   inspector:
     image: projects.registry.vmware.com/cnsi/inspector:0.1
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
   inspection:
     namespaceSelector:
       matchLabels:

--- a/src/frontend/scripts/cloud-native-security-inspector-portal.yaml
+++ b/src/frontend/scripts/cloud-native-security-inspector-portal.yaml
@@ -19,6 +19,6 @@ spec:
       containers:
       - name: cloud-native-security-inspector-frontend
         image: projects.registry.vmware.com/cnsi/portal:0.1
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 3800       


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

## Description

This change contains 2 improvements.

1. Change the imagePullPolicy to IfNotPresent to save unnecessary download.
2. when user run ./deploy.sh install, they will call below functions in Makefile:
deploy -> manifests -> controller-gen -> tidy
But I don't think running tidy during deployment is the right behaviour.

We can let the developer run `go tidy` at debug or build stage, but never at deployment stage. This doesn't make sense.

This makes the user must install go 1.19 in the machine, this doesn't make sense neither