### PR TITLE
do not install the opensearch service in the default project

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -24,7 +24,7 @@ function install_opensearch() {
     check_helm
     helm repo add opensearch https://opensearch-project.github.io/helm-charts/
     helm repo update
-    helm install opensearch-deployment-for-narrows opensearch/opensearch --version 2.8.0
+    helm install opensearch-deployment-for-narrows opensearch/opensearch -n opensearch --version 2.8.0 --create-namespace
     success "OpenSearch installed"
 }
 
@@ -32,7 +32,7 @@ function uninstall_opensearch() {
     note "Uninstalling opensearch"
     check_helm
     helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-    helm uninstall opensearch-deployment-for-narrows || :
+    helm uninstall opensearch-deployment-for-narrows -n opensearch || :
     success "OpenSearch uninstalled"
 }
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -77,40 +77,24 @@ replicaset.apps/cnsi-controller-manager-7c756fd8d8                  1         1 
 
 Now you are able to access the CNSI portal through clusterIp:30150, because the portal is a NodePort service.
 
+Now verify the OpenSearch service is deployed properly:
 ```
 ➜  ~  kubectl get all -n opensearch
 NAME                              READY   STATUS    RESTARTS   AGE
-pod/opensearch-cluster-master-0   1/1     Running   0          2m40s
+pod/opensearch-cluster-master-0   1/1     Running   0          119s
+pod/opensearch-cluster-master-1   1/1     Running   0          119s
+pod/opensearch-cluster-master-2   1/1     Running   0          119s
 
-NAME                                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
-service/opensearch-cluster-master            NodePort    10.105.223.105   <none>        9200:32705/TCP,9300:31004/TCP   2m40s
-service/opensearch-cluster-master-headless   ClusterIP   None             <none>        9200/TCP,9300/TCP               2m40s
+NAME                                         TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
+service/opensearch-cluster-master            ClusterIP   10.108.254.0   <none>        9200/TCP,9300/TCP   11m
+service/opensearch-cluster-master-headless   ClusterIP   None           <none>        9200/TCP,9300/TCP   11m
 
 NAME                                         READY   AGE
-statefulset.apps/opensearch-cluster-master   1/1     2m40s
+statefulset.apps/opensearch-cluster-master   3/3     11m
 ```
-The default username and password are "admin".
-```
-➜  ~  curl -XGET https://10.186.2.130:32705 -u 'admin:admin' --insecure
-{
-  "name" : "opensearch-cluster-master-0",
-  "cluster_name" : "opensearch-cluster",
-  "cluster_uuid" : "ABlUQ9GGS3y0jYKJ1s5QJw",
-  "version" : {
-    "distribution" : "opensearch",
-    "number" : "2.4.0",
-    "build_type" : "tar",
-    "build_hash" : "744ca260b892d119be8164f48d92b8810bd7801c",
-    "build_date" : "2022-11-15T04:42:29.671309257Z",
-    "build_snapshot" : false,
-    "lucene_version" : "9.4.1",
-    "minimum_wire_compatibility_version" : "7.10.0",
-    "minimum_index_compatibility_version" : "7.0.0"
-  },
-  "tagline" : "The OpenSearch Project: https://opensearch.org/"
-}
-```
-We will configure this opensearch endpoint in the CNSI's portal.
+The OpenSearch endpoint is `opensearch-cluster-master.opensearch:9200`.
+
+We will configure this OpenSearch endpoint in the CNSI's portal.
 
 ## Inspect the workload with CNSI
 ### Create a Setting

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -331,7 +331,7 @@ spec:
       generate: true
       liveTime: 3600
       managedBy: true
-      openSearchAddr: https://opensearch-cluster-master.default:9200
+      openSearchAddr: https://opensearch-cluster-master.opensearch:9200
       openSearchEnabled: true
       openSearchPasswd: admin
       openSearchUser: admin
@@ -445,7 +445,7 @@ spec:
       generate: true
       liveTime: 3600
       managedBy: true
-      openSearchAddr: https://opensearch-cluster-master.default:9200
+      openSearchAddr: https://opensearch-cluster-master.opensearch:9200
       openSearchCert: ""
       openSearchEnabled: true
       openSearchPasswd: admin


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

Verified that now the opensearch service can be installed in the openserach namespace, and can be uninstalled properly with oue deploy.sh script.