### PR TITLE
Create a ns if not exist when user has input the workspace n

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -24,7 +24,7 @@ function install_opensearch() {
     check_helm
     helm repo add opensearch https://opensearch-project.github.io/helm-charts/
     helm repo update
-    helm install opensearch-deployment-for-narrows opensearch/opensearch -n opensearch --version 2.8.0 --create-namespace
+    helm install opensearch-deployment-for-narrows opensearch/opensearch -n opensearch --version 2.8.0 --create-namespace --set persistence.enabled=false
     success "OpenSearch installed"
 }
 

--- a/src/controllers/inspectionpolicy_controller.go
+++ b/src/controllers/inspectionpolicy_controller.go
@@ -287,18 +287,17 @@ func (r *InspectionPolicyReconciler) ensureWorkNamespace(ctx context.Context, po
 	var namespace corev1.Namespace
 	err := r.Client.Get(ctx, client.ObjectKey{Name: *ns}, &namespace)
 	// No error, return now.
-	// For none NOTFOUND error, directly return.
-	// For NOTFOUND error, if the work namespace has been set, error should also been returned.
-	if err == nil || !apierrors.IsNotFound(err) || policy.Spec.WorkNamespace != nil {
+	// For non-NOTFOUND error, directly return.
+	if err == nil || !apierrors.IsNotFound(err) {
 		return ns, err
 	}
 
 	// Create namespace now with policy name and set the workNamespace.
 	newOne := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: policy.Name,
+			Name: *ns,
 			Labels: map[string]string{
-				labelOwnerKey: policy.Name,
+				labelOwnerKey: *ns,
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

As a user, when I input the workspace namespace on the UI, I would expect the backend to create such a namespace if it doesn't exist.

Also, as our opensearch installed by deploy.sh is for POC usage only, there is no need to enabled persistence. Because enable that will bring more steps of setting the storage class. However,  the user's K8s cluster is not guranteed to have a storage class installed.