### PR TITLE
fix the issue of omitted docker image

### DIFF
--- a/src/pkg/data/core/types.go
+++ b/src/pkg/data/core/types.go
@@ -43,6 +43,12 @@ func ParseArtifactIDFrom(image, imageID string) ArtifactID {
 	if !strings.Contains(fullRepo, "/") {
 		// The omitted registry means docker.io
 		fullRepo = fmt.Sprintf("docker.io/%s", fullRepo)
+	} else {
+		namespaceOrRegistry := fullRepo[:strings.Index(fullRepo, "/")]
+		if !strings.Contains(namespaceOrRegistry, ".") {
+			// This should be a namespace, the docker.io is omitted
+			fullRepo = fmt.Sprintf("docker.io/%s", fullRepo)
+		}
 	}
 
 	// Digest format repo@sha256:.

--- a/src/pkg/data/core/types_test.go
+++ b/src/pkg/data/core/types_test.go
@@ -83,3 +83,14 @@ func (suite *TypesSuite) TestOmittedRegistryCase() {
 	suite.Equal("mariadb", ID.Repository())
 	suite.Equal("sha256:8c15c3def7ae1bb408c96d322a3cc0346dba9921964d8f9897312fe17e127b90", ID.Digest())
 }
+
+func (suite *TypesSuite) TestOmittedRegistryWithOrg() {
+	image := "federatedai/kubefate:v1.4.5"
+	imageID := "federatedai/kubefate@sha256:13b6d5b836f561fd035819ce53f8a97dfeaf703cddbf0d5974f56c9040f1831"
+	ID := ParseArtifactIDFrom(image, imageID)
+	suite.Equal("v1.4.5", ID.tag)
+	suite.Equal("federatedai", ID.Namespace())
+	suite.Equal("docker.io", ID.Registry())
+	suite.Equal("kubefate", ID.Repository())
+	suite.Equal("sha256:13b6d5b836f561fd035819ce53f8a97dfeaf703cddbf0d5974f56c9040f1831", ID.Digest())
+}


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

## Steps to reproduce the issue

1. Configured image replication on Harbor, the registry is docker.io
2. Installed 2 deployments, their docker images are: "mariadb:10", "federatedai/kubefate:v1.4.5"

## Issue
Only mariadb can be scanned by inspector.

## Root cause
Because our backend can smartly know that mariadb shoud be from docker.io.
However, for federatedai/kubefate:v1.4.5, our backend thinks federatedai is the registry so it didn't add "docker.io" in frond of it.

## Fix
If the prefix has no ".", then it should be just a namespace, the registry is omitted and should be docker.io

## Test
UT passed, will do post-submit test soon