### PR TITLE
fix 3 misc issues

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ KUBECTLCMD=$(shell which kubectl)
 SWAGGER := $(DOCKERCMD) run --rm -it -v $(HOME):$(HOME) -w $(shell pwd) quay.io/goswagger/swagger
 
 REGISTRY ?= projects.registry.vmware.com/cnsi
-IMG_TAG = 0.1
+IMG_TAG = 0.2
 # Image URL to use all building/pushing image targets
 IMG_MANAGER ?= $(REGISTRY)/manager:$(IMG_TAG)
 IMG_CMD_INSPECTOR ?= $(REGISTRY)/inspector:$(IMG_TAG)
@@ -133,9 +133,7 @@ deploy-without-portal: manifests kustomize ## Deploy controller to the K8s clust
 #uninstall:
 
 remove_clusterrolebinding:
-    clean = $(shell kubectl delete clusterrolebinding cnsi-inspector-rolebinding)
-    clean = $(shell kubectl delete clusterrolebinding cnsi-manager-rolebinding)
-    clean = $(shell kubectl delete clusterrolebinding cnsi-proxy-rolebinding)
+	$(shell kubectl delete clusterrolebinding cnsi-inspector-rolebinding)
 
 undeploy: remove_clusterrolebinding ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -

--- a/src/frontend/src/app/view/policy/policy-setting-page/policy-setting-page.component.ts
+++ b/src/frontend/src/app/view/policy/policy-setting-page/policy-setting-page.component.ts
@@ -160,7 +160,7 @@ export class PolicySettingPageComponent implements OnInit {
         elasticSearchCert: [''],
         openSearchEnabled: [true],
         openSearchAddrHeader: ['https://'],
-        openSearchAddr: ['opensearch-cluster-master.default:9200'],
+        openSearchAddr: ['opensearch-cluster-master.opensearch:9200'],
         openSearchUser: ['admin'],
         openSearchPasswd: ['admin'],
       }),


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

This change fix 3 issues:

1. As 0.1 has been released, currently we should not change the image tagged with 0.1, we should play with 0.2.
2. The remove_clusterrolebinding does't work at all.
3. The default opensearch endpoint need a change.

for 2, the cnsi-manager-rolebinding and cnsi-proxy-rolebinding has been handled here:
https://github.com/vmware-tanzu/cloud-native-security-inspector/blob/main/src/Makefile#L157