### PR TITLE
add the rbac by the right way

### DIFF
--- a/src/config/rbac/role.yaml
+++ b/src/config/rbac/role.yaml
@@ -57,6 +57,13 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - deployments
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
   - replicasets
   verbs:
   - create
@@ -86,6 +93,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
 - apiGroups:
   - goharbor.goharbor.io
   resources:
@@ -226,18 +240,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - list
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - nodes
-  verbs:
-  - list
-  - get

--- a/src/controllers/inspectionpolicy_controller.go
+++ b/src/controllers/inspectionpolicy_controller.go
@@ -63,6 +63,8 @@ type InspectionPolicyReconciler struct {
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="batch",resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
+//+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list
+//+kubebuilder:rbac:groups="core",resources=services,verbs=get;list
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

We should use kubebuilder to add the rbac, by adding the code annotaions, instead of changing the rbac file manually.