### PR TITLE
fix the bug when image is replicated from other registries

### DIFF
--- a/src/pkg/data/core.go
+++ b/src/pkg/data/core.go
@@ -71,5 +71,5 @@ type Configurator interface {
 }
 
 type Artifact interface {
-	GetVulnerabilitiesList(ctx context.Context, id core.ArtifactID, skipVerify bool) (*vuln.Report, error)
+	GetVulnerabilitiesList(ctx context.Context, id core.ArtifactID) (*vuln.Report, error)
 }

--- a/src/pkg/data/providers/factory.go
+++ b/src/pkg/data/providers/factory.go
@@ -60,6 +60,6 @@ func NewHarborAdapter(ctx context.Context, kclient k8client.Client, setting *v1a
 
 		ap.WithCache(cc)
 	}
-	ap.WithEndpoint(setting.Spec.DataSource.Endpoint, setting.Spec.DataSource.SkipTLSVerify)
+	ap.WithClientConfig(config)
 	return ap, nil
 }

--- a/src/pkg/data/providers/factory.go
+++ b/src/pkg/data/providers/factory.go
@@ -60,6 +60,6 @@ func NewHarborAdapter(ctx context.Context, kclient k8client.Client, setting *v1a
 
 		ap.WithCache(cc)
 	}
-
+	ap.WithEndpoint(setting.Spec.DataSource.Endpoint, setting.Spec.DataSource.SkipTLSVerify)
 	return ap, nil
 }

--- a/src/pkg/inspection/data/resources.go
+++ b/src/pkg/inspection/data/resources.go
@@ -178,7 +178,7 @@ func (i *ImageItem) generateUUID() {
 // FetchHarborReport fetch the harbor report
 func (i *ImageItem) FetchHarborReport(Adapter providers.Adapter) (*vuln.Report, error) {
 	ctx := context.Background()
-	report, err := Adapter.GetVulnerabilitiesList(ctx, i.ArtifactID, true)
+	report, err := Adapter.GetVulnerabilitiesList(ctx, i.ArtifactID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

Fixes ISSUE #118 

## Description

The risk scanner need to fetch the vulnerability report from harbor.

However, when the image is replicated from dockerhub to harbor. I found that risk scanner cannot get the vulnerability report. This is because there is a bug in the code:
id.Registry() should be docker.io but we must fetch from the harbor instance.

Actually we don't need to send the request like this, we should use the harbor sdk to send the request.
However, there is a [known issue](https://github.com/goharbor/harbor/issues/13468) that makes the sdk not work.

So now we must use the string-url to send the request.

<img width="1269" alt="Screen Shot 2022-12-23 at 14 07 42" src="https://user-images.githubusercontent.com/15973672/209281459-f9294333-6963-4a50-81e0-f234bcb46de7.png">


When the Harbor issue is fixed, we still should use the SDK, that is the right thing to do.