### PR TITLE
fix typo and issue in log

### DIFF
--- a/src/frontend/src/app/view/report/namesapce-polar/namesapce-polar.component.ts
+++ b/src/frontend/src/app/view/report/namesapce-polar/namesapce-polar.component.ts
@@ -43,7 +43,7 @@ export class NamesapcePolarComponent implements OnInit {
           type: 'pie',
           radius: '50%',
           data: [
-            { value: this.abnormal, name: 'AbNormal', itemStyle: {color: '#EE6666'}},
+            { value: this.abnormal, name: 'Abnormal', itemStyle: {color: '#EE6666'}},
             { value: this.normal, name: 'Normal', itemStyle: {color: '#3BA272'} },
           ],
           emphasis: {

--- a/src/frontend/src/app/view/report/packedbubble/packedbubble.component.ts
+++ b/src/frontend/src/app/view/report/packedbubble/packedbubble.component.ts
@@ -46,7 +46,7 @@ export class PackedbubbleComponent implements OnInit {
           type: 'pie',
           radius: '50%',
           data: [
-            { value: this.abnormal, name: 'AbNormal', itemStyle: {color: '#EE6666'}},
+            { value: this.abnormal, name: 'Abnormal', itemStyle: {color: '#EE6666'}},
             { value: this.normal, name: 'Normal', itemStyle: {color: '#3BA272'} },
           ],
           emphasis: {

--- a/src/pkg/runtime/grpool/pool.go
+++ b/src/pkg/runtime/grpool/pool.go
@@ -76,7 +76,7 @@ func (p *GrPool) Start() Pool {
 	if p.queue == nil {
 		p.queue = make(chan Job, defaultQueueSize)
 	}
-	log.Info("Error collector is started", nil)
+	log.Info("Error collector is started")
 
 	// Start the job processing flow.
 	go func() {
@@ -98,7 +98,7 @@ func (p *GrPool) Start() Pool {
 				// Find a worker first.
 				// If all the workers are busy, process workflow will be blocked here.
 				p.workers <- struct{}{}
-				log.Info("worker occupied", nil, "available workers", p.availableWorkers())
+				log.Infof("worker occupied, available workers left: %d", p.availableWorkers())
 
 				// Run job now.
 				go func() {
@@ -107,7 +107,7 @@ func (p *GrPool) Start() Pool {
 						p.wg.Done()
 						// Return the worker.
 						<-p.workers
-						log.Info("worker released", nil, "available workers", p.availableWorkers())
+						log.Infof("worker released, available workers left: %d", p.availableWorkers())
 					}()
 
 					select {
@@ -134,7 +134,7 @@ func (p *GrPool) Start() Pool {
 			}
 		}
 	}()
-	log.Info("Job processor is started", nil)
+	log.Info("Job processor is started")
 	return p
 }
 


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

## Description
Fix 1 typo and several logs.

## Tests
### Before fix
```
2023-01-03T01:00:04Z [INFO] [/workspace/pkg/runtime/grpool/pool.go:79]: Error collector is started<nil>
2023-01-03T01:00:04Z [INFO] [/workspace/pkg/runtime/grpool/pool.go:137]: Job processor is started<nil>
2023-01-03T01:00:04Z [INFO] [/workspace/pkg/inspection/controller.go:287]: Scan workloads under namespacenamespace{Namespace  kube-fate 4b6e0584-34c8-4512-adbc-e7552c0925b2 v1 4742572 }
2023-01-03T01:00:04Z [INFO] [/workspace/pkg/runtime/grpool/pool.go:101]: worker occupied<nil>available workers4294967295
2023-01-03T01:00:04Z [INFO] [/workspace/pkg/inspection/controller.go:310]: Inspecting workloadnamespacekube-fatenamekubefate
2023-01-03T01:00:04Z [INFO] [/workspace/pkg/inspection/controller.go:310]: Inspecting workloadnamespacekube-fatenamemariadb
2023-01-03T01:00:04Z [INFO] [/workspace/pkg/runtime/grpool/pool.go:110]: worker released<nil>available workers0
```

### After fix
Code static scan passed.