### PR TITLE
Change Kubebench to event-driven DaemonSet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,7 @@ dist/
 node_modules/
 coverage/
 .angular/
+bin/
+vendor/
 package-lock.json
 yarn.lock

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ KUBECTLCMD=$(shell which kubectl)
 SWAGGER := $(DOCKERCMD) run --rm -it -v $(HOME):$(HOME) -w $(shell pwd) quay.io/goswagger/swagger
 
 REGISTRY ?= projects.registry.vmware.com/cnsi
-IMG_TAG = 0.2
+IMG_TAG = 0.3
 # Image URL to use all building/pushing image targets
 IMG_MANAGER ?= $(REGISTRY)/manager:$(IMG_TAG)
 IMG_CMD_INSPECTOR ?= $(REGISTRY)/inspector:$(IMG_TAG)

--- a/src/Makefile
+++ b/src/Makefile
@@ -89,7 +89,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 docker-build-all: docker-build-manager docker-build-inspector docker-build-kubebench docker-build-portal docker-build-risk
 
-docker-build-manager: test build-manager ## Build docker image with the manager.
+docker-build-manager: build-manager ## Build docker image with the manager.
 	$(DOCKERCMD) build -t ${IMG_MANAGER} .
 
 docker-build-inspector: build-inspector ## Build docker image with inspector cmd.

--- a/src/api/v1alpha1/inspectionpolicy_types.go
+++ b/src/api/v1alpha1/inspectionpolicy_types.go
@@ -17,8 +17,8 @@ const (
 const (
 	// CronjobInpsection describes the Inspection type of cronjob.
 	CronjobInpsection = "Inpection"
-	// CronjobKubebench describes the Kubebench type of the cronjob.
-	CronjobKubebench = "Kubebench"
+	// DaemonSetKubebench describes the Kubebench type of the cronjob.
+	DaemonSetKubebench = "Kubebench"
 	// CronjobRisk describes the Risk type of the cronjob.
 	CronjobRisk = "Risk"
 )

--- a/src/cmd/kubebench/main.go
+++ b/src/cmd/kubebench/main.go
@@ -12,8 +12,10 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"os"
+	"os/exec"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 	"time"
 )
 
@@ -68,7 +70,7 @@ func scan() {
 		log.Error(err, "unable to retrieve the specified inspection policy")
 		os.Exit(1)
 	}
-	hostname := os.Getenv("hostname")
+	hostname := getHostName()
 	log.Infof("Kubebench scanner running on host:%v", hostname)
 
 	runner := kubebench.NewController().
@@ -81,6 +83,17 @@ func scan() {
 		log.Error(err, "kubebench controller run")
 		os.Exit(1)
 	}
+}
+
+func getHostName() string {
+	out, err := exec.Command("hostname").Output()
+	if err != nil {
+		log.Error("failed to get the hostname in the daemon pod")
+		return ""
+	}
+	output := string(out[:])
+	output = strings.Trim(output, "\n")
+	return output
 }
 
 func main() {

--- a/src/cmd/kubebench/main.go
+++ b/src/cmd/kubebench/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"github.com/fsnotify/fsnotify"
-	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/vmware-tanzu/cloud-native-security-inspector/src/api/v1alpha1"
 	"github.com/vmware-tanzu/cloud-native-security-inspector/src/lib/log"
 	"github.com/vmware-tanzu/cloud-native-security-inspector/src/pkg/inspection/kubebench"
@@ -154,7 +153,7 @@ func main() {
 	log.Info("the watcher has been started to watch the K8s configurations files")
 	for _, path := range pathList {
 		err = watcher.Add(path)
-		logger.Infof("watching path: %s", path)
+		log.Infof("watching path: %s", path)
 		if err != nil {
 			log.Fatalf("failed to add the path %s path, err: %s", path, err)
 		}

--- a/src/cmd/kubebench/main.go
+++ b/src/cmd/kubebench/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/fsnotify/fsnotify"
 	"github.com/vmware-tanzu/cloud-native-security-inspector/src/api/v1alpha1"
 	"github.com/vmware-tanzu/cloud-native-security-inspector/src/lib/log"
 	"github.com/vmware-tanzu/cloud-native-security-inspector/src/pkg/inspection/kubebench"
@@ -12,11 +13,26 @@ import (
 	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
 var (
 	scheme  = runtime.NewScheme()
 	rootCtx = context.Background()
+)
+
+const (
+	varLibEtcdPath                  = "/var/lib/etcd"
+	varLibKubeletPath               = "/var/lib/kubelet"
+	varLibKubeSchedulerPath         = "/var/lib/kube-scheduler"
+	varLibKubeControllerManagerPath = "/var/lib/kube-controller-manager"
+	etcSystemdPath                  = "/etc/systemd"
+	libSystemdPath                  = "/lib/systemd/"
+	srvKubernetesPath               = "/srv/kubernetes/"
+	etcKubernetesPath               = "/etc/kubernetes"
+	usrBinPath                      = "/usr/local/mount-from-host/bin"
+	etcCniNetdPath                  = "/etc/cni/net.d/"
+	optCniBinPath                   = "/opt/cni/bin/"
 )
 
 func init() {
@@ -27,7 +43,7 @@ func init() {
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch;create;update;patch;delete
 
-func main() {
+func scan() {
 	var policy string
 	flag.StringVar(&policy, "policy", "", "name of the inspection policy")
 	flag.Parse()
@@ -64,4 +80,68 @@ func main() {
 		log.Error(err, "kubebench controller run")
 		os.Exit(1)
 	}
+}
+
+func main() {
+	// Create new watcher.
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer watcher.Close()
+	lastScanTime := time.Now().AddDate(0, 0, -1)
+	const coolDownSeconds = 60
+	// Start listening for events.
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					log.Errorf("missed one event %s", event)
+					continue
+				}
+				if event.Has(fsnotify.Write) {
+					log.Infof("modified file: %s", event.Name)
+					now := time.Now()
+					diff := now.Sub(lastScanTime)
+					if diff.Seconds() > coolDownSeconds {
+						lastScanTime = now
+						log.Infof("past %d seconds since the last scan, will trigger a new one", coolDownSeconds)
+						scan()
+					} else {
+						log.Debug("detected frequently change of the file, throttle the scan")
+					}
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					log.Fatal("watcher reports an error: ", err)
+					os.Exit(1)
+				}
+			}
+		}
+	}()
+
+	// Add the paths
+	pathList := []string{
+		varLibEtcdPath,
+		varLibKubeletPath,
+		varLibKubeSchedulerPath,
+		varLibKubeControllerManagerPath,
+		etcSystemdPath,
+		libSystemdPath,
+		srvKubernetesPath,
+		etcKubernetesPath,
+		usrBinPath,
+		etcCniNetdPath,
+		optCniBinPath,
+	}
+	for _, path := range pathList {
+		err = watcher.Add(path)
+		if err != nil {
+			log.Fatalf("failed to add the path %s path, err: %s", path, err)
+		}
+	}
+
+	// Block main goroutine forever.
+	<-make(chan struct{})
 }

--- a/src/config/manager/kustomization.yaml
+++ b/src/config/manager/kustomization.yaml
@@ -15,4 +15,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: projects.registry.vmware.com/cnsi/manager
-  newTag: "0.2"
+  newTag: "0.3"

--- a/src/config/manager/manager.yaml
+++ b/src/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: projects.registry.vmware.com/cnsi/manager:0.2
+        image: projects.registry.vmware.com/cnsi/manager:0.3
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/src/config/rbac/role.yaml
+++ b/src/config/rbac/role.yaml
@@ -57,6 +57,18 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - get

--- a/src/config/samples/policy.yaml
+++ b/src/config/samples/policy.yaml
@@ -12,8 +12,8 @@ spec:
     suspend: false
     concurrencyRule: "Forbid"
   inspector:
-    image: projects.registry.vmware.com/cnsi/inspector:0.2
-    kubebenchImage: projects.registry.vmware.com/cnsi/kubebench:0.2
+    image: projects.registry.vmware.com/cnsi/inspector:0.3
+    kubebenchImage: projects.registry.vmware.com/cnsi/kubebench:0.3
     imagePullPolicy: Always
   inspection:
     namespaceSelector:

--- a/src/controllers/inspectionpolicy_controller.go
+++ b/src/controllers/inspectionpolicy_controller.go
@@ -30,7 +30,7 @@ import (
 const (
 	appLabelKey                     = "app"
 	defaultImage                    = "projects.registry.vmware.com/cnsi/inspector"
-	defaultImageTag                 = "0.2"
+	defaultImageTag                 = "0.3"
 	labelOwnerKey                   = "goharbor.io/policy-working-for"
 	labelTypeKey                    = "cnsi/inspector-type"
 	lastAppliedAnnotation           = "goharbor.io/last-applied-spec"

--- a/src/controllers/inspectionpolicy_controller.go
+++ b/src/controllers/inspectionpolicy_controller.go
@@ -64,6 +64,7 @@ type InspectionPolicyReconciler struct {
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="batch",resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
+//+kubebuilder:rbac:groups="apps",resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list
 //+kubebuilder:rbac:groups="core",resources=services,verbs=get;list
 

--- a/src/controllers/inspectionpolicy_controller.go
+++ b/src/controllers/inspectionpolicy_controller.go
@@ -502,7 +502,7 @@ func (r *InspectionPolicyReconciler) ensureRBAC(ctx context.Context, ns string) 
 		},
 		Subjects: []rbacv1.Subject{
 			{
-				Kind:      sa.Kind,
+				Kind:      "ServiceAccount",
 				Namespace: ns,
 				Name:      saName,
 			},

--- a/src/controllers/inspectionpolicy_controller.go
+++ b/src/controllers/inspectionpolicy_controller.go
@@ -5,6 +5,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
 	"strconv"
 
 	"strings"
@@ -27,6 +28,7 @@ import (
 )
 
 const (
+	appLabelKey                     = "app"
 	defaultImage                    = "projects.registry.vmware.com/cnsi/inspector"
 	defaultImageTag                 = "0.2"
 	labelOwnerKey                   = "goharbor.io/policy-working-for"
@@ -133,8 +135,7 @@ func (r *InspectionPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Process the cronjob for kubebench
 	var statusNeedUpdateForKubebench bool
-	statusNeedUpdateForKubebench, err = r.cronjobForKubebench(ctx, policy)
-
+	statusNeedUpdateForKubebench, err = r.checkKubebench(ctx, policy)
 	// Process the cronjob for risk
 	var statusNeedUpdateForRisk bool
 	statusNeedUpdateForRisk, err = r.cronjobForInspection(ctx, policy, goharborv1.CronjobRisk)
@@ -154,17 +155,105 @@ func (r *InspectionPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return ctrl.Result{}, nil
 }
 
-func (r *InspectionPolicyReconciler) cronjobForKubebench(ctx context.Context, policy *goharborv1.InspectionPolicy) (bool, error) {
+func (r *InspectionPolicyReconciler) checkKubebench(ctx context.Context, policy *goharborv1.InspectionPolicy) (bool, error) {
 	if policy.Spec.Inspector.KubebenchImage == "" {
-		log.Info(nil, "the user doesn't involve KubebenchImage in policy")
+		log.Info(nil, "the user doesn't involve Kubebench Image in policy")
 		return false, nil
 	}
-	if err := r.checkKubebenchCronJob(ctx, policy); err != nil {
-		log.Error(err, "unable to check underlying cronjob CR for kubebench")
-		return false, err
+	var kubebenchDaemonSet appsv1.DaemonSet
+	namespacedName := types.NamespacedName{
+		Name:      fmt.Sprintf("%s-kubebench-daemonset", policy.Name),
+		Namespace: *policy.Spec.WorkNamespace,
 	}
-	return true, nil
+	if err := r.Get(ctx, namespacedName, &kubebenchDaemonSet); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to get information of the kubebench daemonset")
+			return true, err
+		} else {
+			// cannot find the DaemonSet resource
+			dsStruct, err := r.constructKubebenchDaemonSet(policy)
+			if err != nil {
+				log.Error(err, "failed to construct the DaemonSet struct")
+				return true, err
+			} else {
+				err = r.Client.Create(ctx, dsStruct)
+				if err != nil {
+					log.Errorf("failed to create the DaemonSet for kubebench %s, err:", err)
+					return true, err
+				}
+				return false, err
+			}
+		}
+	}
+	log.Debug("The daemonSet is already existing")
+	return false, nil
+}
 
+func (r *InspectionPolicyReconciler) constructKubebenchDaemonSet(
+	policy *goharborv1.InspectionPolicy) (*appsv1.DaemonSet, error) {
+	command := "/kubebench"
+	rootUid := int64(0)
+	fsPolicy := corev1.FSGroupChangeOnRootMismatch
+	container := corev1.Container{
+		Name:            "kubebench",
+		Image:           policy.Spec.Inspector.KubebenchImage,
+		ImagePullPolicy: getImagePullPolicy(policy),
+		Command:         []string{command},
+		Args: []string{
+			"--policy",
+			policy.Name,
+		},
+	}
+	r.addVolumeMountsToContainer(&container)
+	podSpec := corev1.PodSpec{
+		HostPID: true,
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser:           &rootUid,
+			FSGroupChangePolicy: &fsPolicy,
+		},
+		Containers:         []corev1.Container{container},
+		RestartPolicy:      corev1.RestartPolicyAlways,
+		ServiceAccountName: saName,
+		ImagePullSecrets:   policy.Spec.Inspector.ImagePullSecrets,
+	}
+	r.addVolumeToPodSpec(&podSpec)
+	ds := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-kubebench-daemonset", policy.Name),
+			Namespace: *policy.Spec.WorkNamespace,
+			Labels: map[string]string{
+				labelOwnerKey: policy.Name,
+				labelTypeKey:  goharborv1.DaemonSetKubebench,
+			},
+			Annotations: make(map[string]string),
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					appLabelKey: "kubebench",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						appLabelKey: "kubebench",
+					},
+				},
+				Spec: podSpec,
+			},
+		},
+	}
+	// Set owner reference.
+	if err := ctrl.SetControllerReference(policy, &ds, r.Scheme); err != nil {
+		return nil, err
+	}
+	jdata, err := json.Marshal(ds.Spec)
+	if err != nil {
+		return nil, err
+	}
+	ds.Annotations[lastAppliedAnnotation] = string(jdata)
+	log.Infof("Kubebench DaemonSet %s constructed", ds.ObjectMeta.Name)
+	return &ds, nil
 }
 
 func (r *InspectionPolicyReconciler) cronjobForInspection(ctx context.Context, policy *goharborv1.InspectionPolicy,
@@ -253,11 +342,6 @@ func (r *InspectionPolicyReconciler) updatePolicyStatus(policy *goharborv1.Inspe
 			return err
 		}
 	}
-	return nil
-}
-
-func (r *InspectionPolicyReconciler) doKubeBench() error {
-
 	return nil
 }
 
@@ -436,77 +520,6 @@ func (r *InspectionPolicyReconciler) ensureRBAC(ctx context.Context, ns string) 
 	return nil
 }
 
-func (r *InspectionPolicyReconciler) isCronjobCountReady(policy *goharborv1.InspectionPolicy) bool {
-	execCount := len(policy.Status.KubebenchExecutor)
-	if execCount < len(r.nodeList) {
-		return false
-	} else {
-		return true
-	}
-}
-
-func (r *InspectionPolicyReconciler) updatePolicyStatusForKubebench(ctx context.Context,
-	policy *goharborv1.InspectionPolicy, jl batchv1.CronJobList) error {
-	log.Info("Update status of inspection policy for kubebench", "status", policy.Status.Status)
-	for _, job := range jl.Items {
-		ref, err := reference.GetReference(r.Scheme, &job)
-		if err != nil {
-			log.Error(err, "unable to get reference of underlying cronjob for kubebench",
-				"cronjob", job.Name)
-			return err
-		}
-		policy.Status.KubebenchExecutor = append(policy.Status.KubebenchExecutor, ref)
-	}
-	if err := r.Status().Update(ctx, policy); err != nil {
-		log.Error(err, "failed to update status of inspection policy for kubebench")
-		return err
-	}
-	return nil
-}
-
-func (r *InspectionPolicyReconciler) checkKubebenchCronJob(ctx context.Context, policy *goharborv1.InspectionPolicy) error {
-	var jl batchv1.CronJobList
-	if err := r.List(ctx, &jl, client.MatchingLabels{labelOwnerKey: policy.Name, labelTypeKey: goharborv1.CronjobKubebench}); err != nil {
-		return err
-	}
-
-	if (policy.Status.KubebenchExecutor == nil && len(jl.Items) > 0) ||
-		(len(policy.Status.KubebenchExecutor) < len(jl.Items)) {
-		// Update policy status for Kubebench cronjobs
-		if err := r.updatePolicyStatusForKubebench(ctx, policy, jl); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	if r.isCronjobCountReady(policy) {
-		log.Info("Numbers of cronjob for kube-bench has already met the requirement")
-		// Do nothing but keep tracking the status of the cronjobs and update it to policy.
-	} else {
-		log.Info("Numbers of cronjob for kube-bench has not already met the requirement")
-		if len(jl.Items) == 0 {
-			// Nothing found. Will create cronjob.
-			log.Info("Start creating cronjob for kube-bench")
-			crList, err := r.generateKubebenchCronJobCR(policy)
-			if err != nil {
-				log.Error(err, "generateKubebenchCronJobCR error")
-			}
-			for _, cr := range crList {
-				if err := r.Client.Create(ctx, &cr); err != nil {
-					log.Error(err, "unable to create cronjob for kubebench", "cronjob", cr.Name)
-					return err
-				}
-			}
-			return nil
-		} else {
-			// Cronjob have been found but not met the required counts. Will wait for a sec.
-			log.Info("Will wait and see...")
-			return nil
-		}
-	}
-	return nil
-}
-
 func (r *InspectionPolicyReconciler) checkCronJob(ctx context.Context, policy *goharborv1.InspectionPolicy,
 	cronjobType string) (*batchv1.CronJob, error) {
 	var exec *corev1.ObjectReference
@@ -573,107 +586,12 @@ func (r *InspectionPolicyReconciler) addVolumeToPodSpec(podSpec *corev1.PodSpec)
 	}
 }
 
-func (r *InspectionPolicyReconciler) generateKubebenchCronJobCR(policy *goharborv1.InspectionPolicy) ([]batchv1.CronJob, error) {
-	var fl int32 = 1
-	name := "kubebench"
-	command := "/kubebench"
-	image := getImage(policy, goharborv1.CronjobKubebench)
-	var cronjobList []batchv1.CronJob
-
-	for _, node := range r.nodeList {
-		container := corev1.Container{
-			Name:            name,
-			Image:           image,
-			ImagePullPolicy: getImagePullPolicy(policy),
-			Command:         []string{command},
-			Args: []string{
-				"--policy",
-				policy.Name,
-			},
-			Env: []corev1.EnvVar{{Name: "hostname", Value: node}},
-		}
-		r.addVolumeMountsToContainer(&container)
-		log.Infof("added volumemount for container: %v", container)
-		cronjobName := randomName(policy.Name) + "-" + name + "-" + node
-		// no more than 52 characters for cronjobName
-		if len(cronjobName) > 52 {
-			cronjobName = cronjobName[0:51]
-		}
-		meta := metav1.ObjectMeta{
-			Name:      cronjobName,
-			Namespace: *policy.Spec.WorkNamespace,
-			Labels: map[string]string{
-				labelOwnerKey: policy.Name,
-				labelTypeKey:  goharborv1.CronjobKubebench,
-			},
-			Annotations: make(map[string]string),
-		}
-		var containerList []corev1.Container
-		rootUid := int64(0)
-		fsPolicy := corev1.FSGroupChangeOnRootMismatch
-		podSpec := corev1.PodSpec{
-			HostPID:            true,
-			SecurityContext:    &corev1.PodSecurityContext{RunAsUser: &rootUid, FSGroupChangePolicy: &fsPolicy},
-			Containers:         append(containerList, container),
-			RestartPolicy:      corev1.RestartPolicyOnFailure,
-			ServiceAccountName: saName,
-			NodeName:           node,
-		}
-		r.addVolumeToPodSpec(&podSpec)
-
-		cj := &batchv1.CronJob{
-			ObjectMeta: meta,
-			Spec: batchv1.CronJobSpec{
-				Schedule:                   policy.Spec.Schedule,
-				ConcurrencyPolicy:          batchv1.ConcurrencyPolicy(policy.Spec.Strategy.ConcurrencyRule),
-				Suspend:                    policy.Spec.Strategy.Suspend,
-				SuccessfulJobsHistoryLimit: policy.Spec.Strategy.HistoryLimit,
-				FailedJobsHistoryLimit:     &fl,
-				JobTemplate: batchv1.JobTemplateSpec{
-					Spec: batchv1.JobSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: podSpec,
-						},
-					},
-				},
-			},
-		}
-		if policy.Spec.Inspector != nil {
-			if len(policy.Spec.Inspector.ImagePullSecrets) > 0 {
-				cj.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = append(
-					cj.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets,
-					policy.Spec.Inspector.ImagePullSecrets...)
-			}
-		}
-
-		// Set owner reference.
-		if err := ctrl.SetControllerReference(policy, cj, r.Scheme); err != nil {
-			return nil, err
-		}
-
-		jdata, err := json.Marshal(cj.Spec)
-		if err != nil {
-			return nil, err
-		}
-
-		cj.Annotations[lastAppliedAnnotation] = string(jdata)
-		log.Infof("Kubebench Cronjob: %v", (*cj).Name)
-		log.Infof("Kubebench Cronjob Node name: %v", (*cj).Spec.JobTemplate.Spec.Template.Spec.NodeName)
-		cronjobList = append(cronjobList, *cj)
-	}
-
-	return cronjobList, nil
-}
-
 func (r *InspectionPolicyReconciler) generateCronJobCR(policy *goharborv1.InspectionPolicy, cronjobType string) (*batchv1.CronJob, error) {
 	var fl int32 = 1
 	var name, image, command string
 	if cronjobType == goharborv1.CronjobInpsection {
 		name = "inspector"
 		command = "/inspector"
-	} else if cronjobType == goharborv1.CronjobKubebench {
-		name = "kubebench"
-		command = "/kubebench"
 	} else if cronjobType == goharborv1.CronjobRisk {
 		name = "risk"
 		command = "/risk"
@@ -779,13 +697,10 @@ func getImage(policy *goharborv1.InspectionPolicy, cronjobType string) string {
 	if policy.Spec.Inspector != nil {
 		if cronjobType == goharborv1.CronjobInpsection {
 			return policy.Spec.Inspector.Image
-		} else if cronjobType == goharborv1.CronjobKubebench {
-			return policy.Spec.Inspector.KubebenchImage
 		} else if cronjobType == goharborv1.CronjobRisk {
 			return policy.Spec.Inspector.RiskImage
 		}
 	}
-
 	return fmt.Sprintf("%s:%s", defaultImage, defaultImageTag)
 }
 

--- a/src/controllers/setting_controller.go
+++ b/src/controllers/setting_controller.go
@@ -143,6 +143,8 @@ func (r *SettingReconciler) ensureKnownRegistries(ctx context.Context, p provide
 	// register known registries, create or update
 	if set.Spec.KnownRegistries == nil || len(set.Spec.KnownRegistries) == 0 {
 		log.Info("there is no configuration about known registries in the setting")
+		// we should set this to true because a setting without the known registry configuration should be healthy
+		cond.Status = goharborv1alpha1.ConditionStatusTrue
 		return nil
 	}
 	err := p.RegisterKnownRegistries(ctx, set.Spec.KnownRegistries)

--- a/src/frontend/scripts/cloud-native-security-inspector-portal.yaml
+++ b/src/frontend/scripts/cloud-native-security-inspector-portal.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: cloud-native-security-inspector-portal-serviceaccount
       containers:
       - name: cloud-native-security-inspector-frontend
-        image: projects.registry.vmware.com/cnsi/portal:0.2
+        image: projects.registry.vmware.com/cnsi/portal:0.3
         imagePullPolicy: Always
         ports:
           - containerPort: 3800       

--- a/src/frontend/src/app/view/policy/policy-setting-page/policy-setting-page.component.spec.ts
+++ b/src/frontend/src/app/view/policy/policy-setting-page/policy-setting-page.component.spec.ts
@@ -141,7 +141,7 @@ describe('PolicySettingPageComponent', () => {
                 }
               },
               "inspector": {
-                "image": "projects.registry.vmware.com/cnsi/inspector:0.2",
+                "image": "projects.registry.vmware.com/cnsi/inspector:0.3",
                 "imagePullPolicy": "IfNotPresent",
                 "imagePullSecrets": []
               },

--- a/src/frontend/src/app/view/policy/policy-setting-page/policy-setting-page.component.ts
+++ b/src/frontend/src/app/view/policy/policy-setting-page/policy-setting-page.component.ts
@@ -29,15 +29,15 @@ export class PolicySettingPageComponent implements OnInit {
   imageList = [
     {
       name: 'inspector',
-      url: 'projects.registry.vmware.com/cnsi/inspector:0.2'
+      url: 'projects.registry.vmware.com/cnsi/inspector:0.3'
     },
     {
       name: 'kubebench',
-      url: 'projects.registry.vmware.com/cnsi/kubebench:0.2'
+      url: 'projects.registry.vmware.com/cnsi/kubebench:0.3'
     },
     {
       name: 'risk',
-      url: 'projects.registry.vmware.com/cnsi/risk:0.2'
+      url: 'projects.registry.vmware.com/cnsi/risk:0.3'
     }
     
   ]
@@ -391,7 +391,7 @@ export class PolicySettingPageComponent implements OnInit {
           this.policyForm.get('inspectionSetting')?.get('historyLimit')?.setValue(5)
           this.policyForm.get('inspectionSetting')?.get('suspend')?.setValue(false)
           this.policyForm.get('inspectionSetting')?.get('concurrencyRule')?.setValue('Forbid')
-          this.policyForm.get('inspectionSetting')?.get('image')?.setValue('projects.registry.vmware.com/cnsi/inspector:0.2')
+          this.policyForm.get('inspectionSetting')?.get('image')?.setValue('projects.registry.vmware.com/cnsi/inspector:0.3')
           this.policyForm.get('inspectionSetting')?.get('imagePullPolicy')?.setValue('IfNotPresent')
           this.policyForm.get('inspectionSetting')?.get('settingsName')?.setValue('')
           // this.policyForm.get('endpoint')?.setValue(policyList[0].spec.inspection.dataProvider.endpoint)

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/aquasecurity/kube-bench v0.6.10
 	github.com/elastic/go-elasticsearch/v8 v8.4.0
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-openapi/errors v0.20.3
 	github.com/go-openapi/runtime v0.24.2
@@ -54,7 +55,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/src/pkg/data/consumers/opensearch/exporter.go
+++ b/src/pkg/data/consumers/opensearch/exporter.go
@@ -235,7 +235,7 @@ func (o *OpenSearchExporter) SaveCIS(controlsCollection []*check.Controls) error
 
 		res, err = opensearchapi.IndexRequest{
 			Index:      o.indexName,
-			DocumentID: "kubebench-Report_" + o.hostname + "_" + currentTimeData + "_" + names.SimpleNameGenerator.GenerateName(""),
+			DocumentID: "kubebench-Report_" + currentTimeData + "_" + names.SimpleNameGenerator.GenerateName(""),
 			Body:       strings.NewReader(string(doc)),
 			Refresh:    "true",
 		}.Do(context.Background(), o.Client)

--- a/src/test/e2e/inspectionpolicy/inspectionpolicy.yaml
+++ b/src/test/e2e/inspectionpolicy/inspectionpolicy.yaml
@@ -12,9 +12,9 @@ spec:
     suspend: false
     concurrencyRule: "Forbid"
   inspector:
-    image: projects.registry.vmware.com/cnsi/inspector:0.2
-    kubebenchImage: projects.registry.vmware.com/cnsi/kubebench:0.2
-    riskImage: projects.registry.vmware.com/cnsi/risk:0.2
+    image: projects.registry.vmware.com/cnsi/inspector:0.3
+    kubebenchImage: projects.registry.vmware.com/cnsi/kubebench:0.3
+    riskImage: projects.registry.vmware.com/cnsi/risk:0.3
     imagePullPolicy: Always
   inspection:
     namespaceSelector:

--- a/src/tools/installation/yaml/manager.yaml
+++ b/src/tools/installation/yaml/manager.yaml
@@ -187,7 +187,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: projects.registry.vmware.com/cnsi/manager:0.2
+        image: projects.registry.vmware.com/cnsi/manager:0.3
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Fixes ISSUE #158

## Description
KubeBench, a cronjob, has issues:
1. Have gap of scanning.
2. Have necessary scans which waste the resource.

KebeBench, a DaemonSet, has benefits:
1. No gap of scanning.
2. Only necessary scans are triggered.
3. The scanners on each node is independent.

The design:
1. Anyway, when the daemon is started, scan for once.
2. Then the scanner will watch the K8s files we mounted to the container, once the file is modified on the host, trigger one more round of scanning on the host.
3. To avoid flooding, we have a throttling mechanism. There will be no repetive scanning within one minutes when there are more that 1 file modification events.

Other changes:
1. bump the version to 0.3.
2. e2e test should not be run during docker-build-all
3. Fix a bug which cause setting to be unhealth when no known resource is added in the setting. 
4. Fix a bug which cause an error log when creating the cluster role binding.

## Tests
Have uploaded the new 0.3 images to DockerHub.
### After fix
1. Verified that the DaemonSet is up. 
2. Verified that there is a kubebench image created on each node.
3. Verified that when we changed a configuration in the directory we are watching, the kubebench scanner on that node will be triggered once.
4. Verified that The UI looks still as before.
5. Verified that the setting is healthy whe no known resource is added.
6. Verified that there is no weird logs in the manager pod and the kubebench pod.
