### PR TITLE
Add governor api call provision to send cluster telemetry data

### DIFF
--- a/src/api/v1alpha1/inspectionpolicy_types.go
+++ b/src/api/v1alpha1/inspectionpolicy_types.go
@@ -114,6 +114,24 @@ type Assessment struct {
 	// ElasticSearch certificate for the client
 	// +kubebuilder:validation:Optional
 	OpenSearchCert string `json:"openSearchCert"`
+	// Indicate whether to config of governor
+	Governor Governor `json:"governor"`
+}
+
+// Governor contains policies for governor to send report
+type Governor struct {
+	// Indicate whether to send the reports to governor
+	// +kubebuilder:default:=false
+	Enabled bool `json:"enabled"`
+	// Unique identifier of the cluster
+	// +kubebuilder:validation:Optional
+	ClusterID string `json:"clusterId"`
+	// Api url to send telemetry data
+	// +kubebuilder:validation:Optional
+	URL string `json:"url"`
+	// Api token for user authentication
+	// +kubebuilder:validation:Optional
+	APIToken string `json:"apiToken"`
 }
 
 // FollowupAction defines what actions should be applied when security expectations are matched.

--- a/src/api/v1alpha1/workload.go
+++ b/src/api/v1alpha1/workload.go
@@ -3,6 +3,7 @@
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -39,6 +40,8 @@ var AllWorkloads = []string{
 type Workload struct {
 	// For pure Pod, no object reference.
 	corev1.ObjectReference `json:"metadata"`
+	// Replicas of this workload.
+	Replicas appsv1.ReplicaSet `json:"replicas"`
 	// Pods of this workload.
 	Pods []*Pod `json:"pods"`
 }

--- a/src/config/crd/bases/goharbor.goharbor.io_assessmentreports.yaml
+++ b/src/config/crd/bases/goharbor.goharbor.io_assessmentreports.yaml
@@ -128,6 +128,23 @@ spec:
                       elasticSearchUser:
                         description: ElasticSearch username for the client
                         type: string
+                      governor:
+                        description: Indicate whether to config of governor
+                        properties:
+                          enabled:
+                            default: false
+                            description: Indicate whether to send the reports to governor
+                            type: boolean
+                          clusterId:
+                            description: Unique identifier of the cluster
+                            type: string
+                          url:
+                            description: Api url to send telemetry data
+                            type: string
+                          apiToken:
+                            description: Api token for user authentication
+                            type: string
+                        type: object
                       format:
                         default: YAML
                         description: Format of the assessment report data.

--- a/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
+++ b/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
@@ -179,6 +179,23 @@ spec:
                       openSearchUser:
                         description: ElasticSearch username for the client
                         type: string
+                      governor:
+                        description: Indicate whether to config of governor
+                        properties:
+                          enabled:
+                            default: false
+                            description: Indicate whether to send the reports to governor
+                            type: boolean
+                          clusterId:
+                            description: Unique identifier of the cluster
+                            type: string
+                          url:
+                            description: Api url to send telemetry data
+                            type: string
+                          apiToken:
+                            description: Api token for user authentication
+                            type: string
+                        type: object
                     required:
                     - elasticSearchEnabled
                     - format

--- a/src/config/samples/policy.yaml
+++ b/src/config/samples/policy.yaml
@@ -57,6 +57,11 @@ spec:
       openSearchAddr: "https://opensearch-cluster-master.default:9200"
       openSearchUser: "admin"
       openSearchPasswd: "admin"
+      governor:
+        enabled: true
+        clusterId: "65a03970-c53a-4ba1-8d1f-42c9f95d2761"
+        url: "app-catalog.vmware.com/api"
+        apiToken: "n6yDMkMEghPUYJDGsn39I_GYNnPh4Vi-LnaH2URjpgwcXbFIVYzMU-n8LRzTJGKO"
     baselines:
       - kind: "vulnerability"
         baseline: "High"

--- a/src/go.mod
+++ b/src/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
+	gitlab.eng.vmware.com/vac/catalog-governor/api-specs/catalog-governor-service-rest/go-client v0.0.0-20230213153333-158da97aac53
 	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4
 	k8s.io/apiserver v0.25.4

--- a/src/go.sum
+++ b/src/go.sum
@@ -638,6 +638,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/gopher-lua v0.0.0-20171031051903-609c9cd26973/go.mod h1:aEV29XrmTYFr3CiRxZeGHpkvbwq+prZduBqMaascyCU=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+gitlab.eng.vmware.com/vac/catalog-governor/api-specs/catalog-governor-service-rest/go-client v0.0.0-20230213153333-158da97aac53 h1:a1Xa7i9FOnW72qQBC7pPTLrcmUcu4/dS0fpxqAGxQDs=
+gitlab.eng.vmware.com/vac/catalog-governor/api-specs/catalog-governor-service-rest/go-client v0.0.0-20230213153333-158da97aac53/go.mod h1:Z3g5cIHSpGMDg7W8dXek1xsxZn4ZsOqNCu5vBXY0DXM=
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
@@ -809,6 +811,7 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 h1:nt+Q6cXKz4MosCSpnbMtqiQ8Oz0pxTef2B4Vca2lvfk=

--- a/src/pkg/data/consumers/governor/exporter.go
+++ b/src/pkg/data/consumers/governor/exporter.go
@@ -1,0 +1,62 @@
+package consumers
+
+import (
+	"context"
+	"errors"
+	api "github.com/vmware-tanzu/cloud-native-security-inspector/src/api/v1alpha1"
+	openapi "gitlab.eng.vmware.com/vac/catalog-governor/api-specs/catalog-governor-service-rest/go-client"
+	"net/http"
+)
+
+type GovernorExporter struct {
+	Report    *api.AssessmentReport
+	ClusterID string
+	ApiURL    string
+	ApiToken  string
+}
+
+// SendReportToGovernor is used to send report to governor url http end point.
+func (g GovernorExporter) SendReportToGovernor() error {
+	// Get api request model from assessment report.
+	kubernetesCluster := getAPIRequest(*g.Report)
+
+	// Create api client to governor api.
+	apiClient := openapi.NewAPIClient(openapi.NewConfiguration())
+	apiSaveClusterRequest := apiClient.ClustersApi.UpdateTelemetry(context.Background(), g.ClusterID)
+
+	// Call api cluster to send telemetry data and get response.
+	response, err := apiSaveClusterRequest.KubernetesTelemetryRequest(kubernetesCluster).Execute()
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusOK {
+		return errors.New(response.Status)
+	}
+
+	return nil
+}
+
+// getAPIRequest is used to map assessment report to client model.
+func getAPIRequest(doc api.AssessmentReport) openapi.KubernetesTelemetryRequest {
+	kubernetesCluster := openapi.NewKubernetesTelemetryRequestWithDefaults()
+	for _, nsa := range doc.Spec.NamespaceAssessments {
+		for _, workloadAssessment := range nsa.WorkloadAssessments {
+			kubernetesWorkloads := openapi.NewKubernetesWorkloadWithDefaults()
+			kubernetesWorkloads.Name = workloadAssessment.Workload.Name
+			kubernetesWorkloads.Kind = workloadAssessment.Workload.Kind
+			kubernetesWorkloads.Namespace = nsa.Namespace.Name
+			kubernetesWorkloads.Replicas = *workloadAssessment.Workload.Replicas.Spec.Replicas
+			for _, pod := range workloadAssessment.Workload.Pods {
+				containerData := openapi.NewContainerWithDefaults()
+				for _, container := range pod.Containers {
+					containerData.Name = container.Name
+					containerData.ImageId = container.ImageID
+					containerData.Image = container.Image
+					kubernetesWorkloads.Containers = append(kubernetesWorkloads.Containers, *containerData)
+				}
+			}
+			kubernetesCluster.Workloads = append(kubernetesCluster.Workloads, *kubernetesWorkloads)
+		}
+	}
+	return *kubernetesCluster
+}


### PR DESCRIPTION
Added http api call support to send cluster informations along with all workloads to VAC.
Added logic to get replica sets informations along with others.