### PR TITLE
Support insight functionality by data from opensearch

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/apimachinery v0.25.4
 	k8s.io/apiserver v0.25.4
 	k8s.io/client-go v0.25.4
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.13.1
 	sigs.k8s.io/e2e-framework v0.0.8
 )
@@ -156,7 +157,6 @@ require (
 	k8s.io/component-base v0.25.4 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/src/pkg/inspectors/imagescanner/pkg/controller.go
+++ b/src/pkg/inspectors/imagescanner/pkg/controller.go
@@ -140,6 +140,7 @@ func (c *controller) Run(ctx context.Context, policy *v1alpha1.InspectionPolicy)
 
 	// Assessment report.
 	report := itypes.AssessmentReport{
+		TimeStamp:            time.Now().Format(time.RFC3339),
 		NamespaceAssessments: make([]*itypes.NamespaceAssessment, 0),
 	}
 
@@ -383,7 +384,7 @@ func ExportImageReports(report itypes.AssessmentReport, pl *v1alpha1.InspectionP
 				for _, container := range pod.Containers {
 					var doc itypes.AssessmentReportDoc
 					doc.PolicyName = pl.Name
-					doc.CreateTimestamp = time.Now().Format(time.RFC3339)
+					doc.CreateTimestamp = report.TimeStamp
 					doc.DocId = fmt.Sprintf("%s-%s", container.Name, doc.CreateTimestamp)
 					doc.UID = uuid.NewString()
 					doc.Namespace = pod.Namespace

--- a/src/pkg/inspectors/imagescanner/types/report.go
+++ b/src/pkg/inspectors/imagescanner/types/report.go
@@ -48,5 +48,6 @@ type AssessmentError struct {
 
 // AssessmentReport struct definition
 type AssessmentReport struct {
+	TimeStamp            string                 `json:"timeStamp"`
 	NamespaceAssessments []*NamespaceAssessment `json:"namespaceAssessments"`
 }

--- a/src/pkg/inspectors/kubebench/pkg/controller.go
+++ b/src/pkg/inspectors/kubebench/pkg/controller.go
@@ -154,7 +154,7 @@ func (c *controller) constructCISExportStruct(pl *v1alpha1.InspectionPolicy, che
 		return nil
 	}
 	reportData := &v1alpha1.ReportData{
-		Source:       "kubebench",
+		Source:       "kubebench_report",
 		ExportConfig: pl.Spec.Inspector.ExportConfig,
 		Payload:      string(bytes),
 	}

--- a/src/pkg/inspectors/kubebench/pkg/controller.go
+++ b/src/pkg/inspectors/kubebench/pkg/controller.go
@@ -141,10 +141,12 @@ func (c *controller) Run(ctx context.Context, policy *v1alpha1.InspectionPolicy)
 }
 
 func (c *controller) constructCISExportStruct(pl *v1alpha1.InspectionPolicy, checkControls *check.Controls) *v1alpha1.ReportData {
+	nowTime := time.Now().Format(time.RFC3339)
 	cisReport := types.CISReport{
 		Controls:        *checkControls,
-		CreateTimestamp: time.Now().Format(time.RFC3339),
+		CreateTimestamp: nowTime,
 		NodeName:        c.hostname,
+		DocID:           "kubebench-report-" + nowTime,
 	}
 	bytes, err := json.Marshal(cisReport)
 	if err != nil {

--- a/src/pkg/inspectors/kubebench/types/report.go
+++ b/src/pkg/inspectors/kubebench/types/report.go
@@ -5,5 +5,6 @@ import "github.com/aquasecurity/kube-bench/check"
 type CISReport struct {
 	check.Controls
 	CreateTimestamp string `json:"createTime"`
-	NodeName        string `json:"node_name"`
+	NodeName        string `json:"nodeName"`
+	DocID           string `json:"docID"`
 }

--- a/src/pkg/inspectors/riskmanager/server.go
+++ b/src/pkg/inspectors/riskmanager/server.go
@@ -169,7 +169,7 @@ func (s *Server) exportRiskReport(risks riskdata.RiskCollection) error {
 	riskReport := &types.RiskReport{
 		ReportDetail:    details,
 		CreateTimestamp: currentTimeData,
-		DocID:           "risk-report" + currentTimeData,
+		DocID:           "risk-report-" + currentTimeData,
 	}
 	reportToBeSent := s.constructRiskExportStruct(riskReport)
 	if reportToBeSent != nil {

--- a/src/pkg/inspectors/riskmanager/server.go
+++ b/src/pkg/inspectors/riskmanager/server.go
@@ -169,6 +169,7 @@ func (s *Server) exportRiskReport(risks riskdata.RiskCollection) error {
 	riskReport := &types.RiskReport{
 		ReportDetail:    details,
 		CreateTimestamp: currentTimeData,
+		DocID:           "risk-report" + currentTimeData,
 	}
 	reportToBeSent := s.constructRiskExportStruct(riskReport)
 	if reportToBeSent != nil {

--- a/src/pkg/inspectors/riskmanager/types/report.go
+++ b/src/pkg/inspectors/riskmanager/types/report.go
@@ -14,4 +14,5 @@ type RiskDetail struct {
 type RiskReport struct {
 	ReportDetail    []RiskDetail
 	CreateTimestamp string `json:"createTime"`
+	DocID           string `json:"docID"`
 }


### PR DESCRIPTION
Previously we have a CR called assessmentReport, which help to store information about workloads, pods, namespace and vulnerabilities information.

Now we have remove the CR but UI still need the data. So I send one copy of the AssessmentReport struct to opensearch. Which supports the previous UI insight functionality to make sure there is no regression. The report's "source" is called "insight_report". When it is sent to the exporter, the index will be set to "insight_report" automatically based on the "source" field. What UI will do is to fetch the latest report from OpenSearch, then show the details on the insight UI.

This should be a short term plan because currently the insight has a dependency on the image scanner. But, the insight should work with any scanner enabled. This can be enhanced in the future, currently we just make sure no regression.

Also, add docId for the kubebench report and risk report to avoid meaningless report name.
Also, add the timeStamp for the insight report to support UI to show the "last check time"


Test after fix:

![Screenshot 2023-03-06 at 22 38 38](https://user-images.githubusercontent.com/15973672/223141883-1e52974e-a834-489b-be12-65e769549872.png)

![Screenshot 2023-03-06 at 22 36 48](https://user-images.githubusercontent.com/15973672/223141894-b2ac9df8-a5d0-48b5-b134-ba97be3d2651.png)

![Screenshot 2023-03-06 at 22 37 59](https://user-images.githubusercontent.com/15973672/223141914-fa66221c-c7b0-4631-aa0f-2c094f9ec63a.png)

