### PR TITLE
skip watching /var/lib/etcd/member/ for kubebench scanner

### DIFF
--- a/src/pkg/inspectors/kubebench/cmd/main.go
+++ b/src/pkg/inspectors/kubebench/cmd/main.go
@@ -158,6 +158,7 @@ func main() {
 	var fullDirList []string
 	exceptPaths := []string{
 		"/var/lib/kubelet/pods", // This is under kubelet but is not about k8s configurations
+		"/var/lib/etcd/member/", // This is under etcd, can be frequently changed but is not about k8s configurations
 	}
 	for _, rootPath := range rootPathList {
 		readTheSubPaths(rootPath, &fullDirList, &exceptPaths)


### PR DESCRIPTION
In a 3 node k8s cluster setup by kubeadm, find below false alarm in kubebench scanner's log:

```
2023-03-06T15:21:50Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/snap/db
2023-03-06T15:21:51Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/wal/0000000000000000-0000000000000000.wal
2023-03-06T15:21:51Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/wal/0000000000000000-0000000000000000.wal
2023-03-06T15:21:51Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/snap/db
2023-03-06T15:21:51Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/snap/db
2023-03-06T15:21:51Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/wal/0000000000000000-0000000000000000.wal
2023-03-06T15:21:51Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/wal/0000000000000000-0000000000000000.wal
2023-03-06T15:21:52Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/snap/db
2023-03-06T15:21:52Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/snap/db
2023-03-06T15:21:54Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/wal/0000000000000000-0000000000000000.wal
2023-03-06T15:21:54Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/wal/0000000000000000-0000000000000000.wal
2023-03-06T15:21:54Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/snap/db
2023-03-06T15:21:54Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/snap/db
2023-03-06T15:21:55Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/wal/0000000000000000-0000000000000000.wal
2023-03-06T15:21:55Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/snap/db
2023-03-06T15:21:55Z [INFO] [/workspace/pkg/inspectors/kubebench/cmd/main.go:122]: modified file: /var/lib/etcd/member/snap/db
```

This is because we should not monitor  "/var/lib/etcd/member/"