### PR TITLE
Feat/default fields optional

### DIFF
--- a/src/api/v1alpha1/inspectionpolicy_types.go
+++ b/src/api/v1alpha1/inspectionpolicy_types.go
@@ -64,6 +64,7 @@ type DataProvider struct {
 type Connection struct {
 	// Insecure HTTP client will be used to connect to the provider.
 	// +kubebuilder:default:=true
+	// +kubebuilder:validation:Optional
 	Insecure bool `json:"insecure"`
 }
 
@@ -71,21 +72,26 @@ type Connection struct {
 type Assessment struct {
 	// Generate indicates whether generate the assessment report or not.
 	// +kubebuilder:default:=true
+	// +kubebuilder:validation:Optional
 	Generate bool `json:"generate"`
 	// Format of the assessment report data.
 	// +kubebuilder:validation:Enum:=JSON;YAML
 	// +kubebuilder:default:=YAML
+	// +kubebuilder:validation:Optional
 	Format string `json:"format"`
 	// Live time of the generated report.
 	// Unit is second.
 	// +kubebuilder:default:=86400
+	// +kubebuilder:validation:Optional
 	LiveTime int64 `json:"liveTime"`
 	// Indicate whether the assessment reports are managed by the policy.
 	// If it is set to true, then the assessment report is owned by the policy.
 	// +kubebuilder:default:=false
+	// +kubebuilder:validation:Optional
 	ManagedBy bool `json:"managedBy"`
 	// Indicate whether to store the reports to elasticsearch
 	// +kubebuilder:default:=false
+	// +kubebuilder:validation:Optional
 	ElasticSearchEnabled bool `json:"elasticSearchEnabled"`
 	// ElasticSearch endpoint
 	// +kubebuilder:validation:Optional
@@ -101,6 +107,7 @@ type Assessment struct {
 	ElasticSearchCert string `json:"elasticSearchCert"`
 	// Indicate whether to store the reports to opensearch
 	// +kubebuilder:default:=false
+	// +kubebuilder:validation:Optional
 	OpenSearchEnabled bool `json:"openSearchEnabled"`
 	// ElasticSearch endpoint
 	// +kubebuilder:validation:Optional
@@ -123,6 +130,7 @@ type Assessment struct {
 type Governor struct {
 	// Indicate whether to send the reports to governor
 	// +kubebuilder:default:=false
+	// +kubebuilder:validation:Optional
 	Enabled bool `json:"enabled"`
 	// Unique identifier of the cluster
 	// +kubebuilder:validation:Optional
@@ -188,6 +196,7 @@ type InspectionConfiguration struct {
 type Strategy struct {
 	// HistoryLimit limits the max number of the completed inspections.
 	// +kubebuilder:default:=25
+	// +kubebuilder:validation:Optional
 	HistoryLimit *int32 `json:"historyLimit"`
 	// Suspend the subsequent inspections temporarily.
 	// +kubebuilder:validation:Optional
@@ -195,6 +204,7 @@ type Strategy struct {
 	// ConcurrencyRule indicates how to handle the overlapped inspector processes.
 	// +kubebuilder:validation:Enum:=Allow;Forbid;Replace
 	// +kubebuilder:default:=Forbid
+	// +kubebuilder:validation:Optional
 	ConcurrencyRule ConcurrencyRule `json:"concurrencyRule"`
 }
 
@@ -211,6 +221,7 @@ type Inspector struct {
 	RiskImage string `json:"riskImage"`
 	// Image pull policy.
 	// +kubebuilder:default:=IfNotPresent
+	// +kubebuilder:validation:Optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy"`
 	// Image pull secrets.
 	// +kubebuilder:validation:Optional

--- a/src/api/v1alpha1/inspectionpolicy_types.go
+++ b/src/api/v1alpha1/inspectionpolicy_types.go
@@ -257,6 +257,7 @@ type InspectionPolicySpec struct {
 	Inspection InspectionConfiguration `json:"inspection"`
 
 	// Strategy of the inspector.
+	// +kubebuilder:validation:Optional
 	Strategy Strategy `json:"strategy"`
 
 	// Inspector (image) for doing the inspection.

--- a/src/config/crd/bases/goharbor.goharbor.io_assessmentreports.yaml
+++ b/src/config/crd/bases/goharbor.goharbor.io_assessmentreports.yaml
@@ -143,11 +143,12 @@ spec:
                       governor:
                         description: Indicate whether to config of governor
                         properties:
-                          cspSecretName:
-                            description: Secret name where CSP api token is stored in cnsi-system namespace
-                            type: string
                           clusterId:
                             description: Unique identifier of the cluster
+                            type: string
+                          cspSecretName:
+                            description: Secret name where CSP api token is stored
+                              in cnsi-system namespace
                             type: string
                           enabled:
                             default: false
@@ -156,8 +157,6 @@ spec:
                           url:
                             description: Api url to send telemetry data
                             type: string
-                        required:
-                        - enabled
                         type: object
                       liveTime:
                         default: 86400
@@ -186,13 +185,6 @@ spec:
                       openSearchUser:
                         description: ElasticSearch username for the client
                         type: string
-                    required:
-                    - elasticSearchEnabled
-                    - format
-                    - generate
-                    - liveTime
-                    - managedBy
-                    - openSearchEnabled
                     type: object
                   baselines:
                     description: Baselines of cluster compliance.

--- a/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
+++ b/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
@@ -155,11 +155,12 @@ spec:
                       governor:
                         description: Indicate whether to config of governor
                         properties:
-                          cspSecretName:
-                            description: Secret name where CSP api token is stored in cnsi-system namespace
-                            type: string
                           clusterId:
                             description: Unique identifier of the cluster
+                            type: string
+                          cspSecretName:
+                            description: Secret name where CSP api token is stored
+                              in cnsi-system namespace
                             type: string
                           enabled:
                             default: false
@@ -168,8 +169,6 @@ spec:
                           url:
                             description: Api url to send telemetry data
                             type: string
-                        required:
-                        - enabled
                         type: object
                       liveTime:
                         default: 86400
@@ -198,13 +197,6 @@ spec:
                       openSearchUser:
                         description: ElasticSearch username for the client
                         type: string
-                    required:
-                    - elasticSearchEnabled
-                    - format
-                    - generate
-                    - liveTime
-                    - managedBy
-                    - openSearchEnabled
                     type: object
                   baselines:
                     description: Baselines of cluster compliance.
@@ -361,8 +353,6 @@ spec:
                   riskImage:
                     description: Image of the risk.
                     type: string
-                required:
-                - imagePullPolicy
                 type: object
               schedule:
                 description: 'Schedule of the inspector. Cron format. Reference: https://en.wikipedia.org/wiki/Cron'
@@ -396,9 +386,6 @@ spec:
                   suspend:
                     description: Suspend the subsequent inspections temporarily.
                     type: boolean
-                required:
-                - concurrencyRule
-                - historyLimit
                 type: object
               workNamespace:
                 description: WorkNamespace specify the namespace for creating the

--- a/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
+++ b/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
@@ -398,7 +398,6 @@ spec:
             - inspection
             - schedule
             - settingsName
-            - strategy
             type: object
           status:
             description: InspectionPolicyStatus defines the observed state of InspectionPolicy

--- a/src/go.mod
+++ b/src/go.mod
@@ -143,7 +143,6 @@ require (
 	go.uber.org/zap v1.23.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
-	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect


### PR DESCRIPTION
BEGONIA-78

## Description
All the fields in the inspectional policy which have default values are made Optional.

## Tests
### Before fix
Inspection Policy :
```
apiVersion: goharbor.goharbor.io/v1alpha1
kind: InspectionPolicy
metadata:
  name: governor-inspectionpolicy
spec:
  settingsName: harbor-setting
  enabled: true
  workNamespace: governor-cronjobs
  schedule: '*/1 * * * *'
  strategy:
    historyLimit: 2
    suspend: false
    concurrencyRule: Forbid
  inspector:
    image: projects.registry.vmware.com/cnsi/dev/inspector:t1
    imagePullPolicy: IfNotPresent
  inspection:
    namespaceSelector:
      matchLabels:
        app: nginx
    assessment:
      elasticSearchEnabled: false
      openSearchEnabled: false
      generate: true
      format: YAML
      liveTime: 3600
      managedBy: true
      governor:
        enabled: true
        clusterId: 6e476de6-168b-4d75-9b9d-a8802333969a
        url: https://api.int.app-catalog.vmware.com/catalog-governor/v1
        cspSecretName: csp-secret
    baselines:
    - baseline: High
      kind: vulnerability
      scheme: application/vnd.security.vulnerability.report; version=1.1
      version: v1.1
    actions:
    - kind: quarantine_vulnerable_workload

```

### After fix

```
apiVersion: goharbor.goharbor.io/v1alpha1
kind: InspectionPolicy
metadata:
  name: governor-inspectionpolicy
spec:
  settingsName: harbor-setting
  enabled: true
  workNamespace: governor-cronjobs
  schedule: '*/1 * * * *'
  inspector:
    image: projects.registry.vmware.com/cnsi/dev/inspector:t1
  inspection:
    namespaceSelector:
      matchLabels:
        app: nginx
    assessment:
      governor:
        enabled: true
        clusterId: 6e476de6-168b-4d75-9b9d-a8802333969a
        url: https://api.int.app-catalog.vmware.com/catalog-governor/v1
        cspSecretName: csp-secret
    baselines:
    - baseline: High
      kind: vulnerability
      scheme: application/vnd.security.vulnerability.report; version=1.1
      version: v1.1

```
