### PR TITLE
fix the way the scanner get the namespace of the narrows system

### DIFF
--- a/src/pkg/exporter/inputs/util.go
+++ b/src/pkg/exporter/inputs/util.go
@@ -18,12 +18,9 @@ func PostReport(exportStruct *v1alpha1.ReportData) error {
 		log.Error(err, "failed to marshal the report data into the protocol")
 		return err
 	}
-	var ns string
-	if b, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err != nil {
-		log.Error(err, "failed to read the namespace from file")
+	ns := os.Getenv("NARROWS_NAMESPACE")
+	if ns == "" {
 		ns = "cnsi-system"
-	} else {
-		ns = string(b)
 	}
 	resp, err := http.Post(
 		// servicename.namespace.svc.cluster.local


### PR DESCRIPTION
Before fix, the scanners actually get the namespace of themselves.

We allow the scanners to be in a different namespace of narrows system. 

So this time I read the namespace in the manager pod, when provisioning the cronjobs and the daemonsets, the manager will pass the namespace in to the env. Then the scanners are able to find the expoter is in which namespace.