### PR TITLE
Handled settingName and strategy in controller manager for workloadsc…

### DIFF
--- a/src/api/v1alpha1/inspectionpolicy_types.go
+++ b/src/api/v1alpha1/inspectionpolicy_types.go
@@ -163,7 +163,6 @@ type Strategy struct {
 	// +kubebuilder:validation:Optional
 	HistoryLimit *int32 `json:"historyLimit"`
 	// Suspend the subsequent inspections temporarily.
-	// +kubebuilder:default:=false
 	// +kubebuilder:validation:Optional
 	Suspend *bool `json:"suspend,omitempty"`
 	// ConcurrencyRule indicates how to handle the overlapped inspector processes.
@@ -227,6 +226,7 @@ type InspectionPolicySpec struct {
 	Inspection InspectionConfiguration `json:"inspection"`
 
 	// Strategy of the inspector.
+	// +kubebuilder:default:={suspend: false}
 	// +kubebuilder:validation:Optional
 	Strategy Strategy `json:"strategy"`
 

--- a/src/api/v1alpha1/inspectionpolicy_types.go
+++ b/src/api/v1alpha1/inspectionpolicy_types.go
@@ -146,23 +146,6 @@ type OpensearchOutputConfig struct {
 	MutualTLS bool   `json:"mutualTLS"`
 }
 
-// Governor contains policies for governor to send report
-type Governor struct {
-	// Indicate whether to send the reports to governor
-	// +kubebuilder:default:=false
-	// +kubebuilder:validation:Optional
-	Enabled bool `json:"enabled"`
-	// Unique identifier of the cluster
-	// +kubebuilder:validation:Optional
-	ClusterID string `json:"clusterId"`
-	// Api url to send telemetry data
-	// +kubebuilder:validation:Optional
-	URL string `json:"url"`
-	// Secret name where CSP api token is stored in cnsi-system namespace
-	// +kubebuilder:validation:Optional
-	CspSecretName string `json:"cspSecretName"`
-}
-
 // ReportData defines the protocol between scanners and exporters
 type ReportData struct {
 	// Source indicates the report is from which source
@@ -180,6 +163,7 @@ type Strategy struct {
 	// +kubebuilder:validation:Optional
 	HistoryLimit *int32 `json:"historyLimit"`
 	// Suspend the subsequent inspections temporarily.
+	// +kubebuilder:default:=false
 	// +kubebuilder:validation:Optional
 	Suspend *bool `json:"suspend,omitempty"`
 	// ConcurrencyRule indicates how to handle the overlapped inspector processes.

--- a/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
+++ b/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
@@ -326,6 +326,8 @@ spec:
                   DataSource is the data source definitions.'
                 type: string
               strategy:
+                default:
+                  suspend: false
                 description: Strategy of the inspector.
                 properties:
                   concurrencyRule:
@@ -344,7 +346,6 @@ spec:
                     format: int32
                     type: integer
                   suspend:
-                    default: false
                     description: Suspend the subsequent inspections temporarily.
                     type: boolean
                 type: object

--- a/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
+++ b/src/config/crd/bases/goharbor.goharbor.io_inspectionpolicies.yaml
@@ -344,6 +344,7 @@ spec:
                     format: int32
                     type: integer
                   suspend:
+                    default: false
                     description: Suspend the subsequent inspections temporarily.
                     type: boolean
                 type: object

--- a/src/controllers/inspectionpolicy_controller.go
+++ b/src/controllers/inspectionpolicy_controller.go
@@ -128,12 +128,14 @@ func (r *InspectionPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	policy.Spec.WorkNamespace = wns
 
 	// Ensure Setting is correctly configured.
-	datasource, err := r.EnsureSettings(ctx, policy)
-	if err != nil {
-		log.Error(err, "unable to ensure the settings in inspection policy")
-		return ctrl.Result{}, err
+	if policy.Spec.Inspector.Image != "" || policy.Spec.Inspector.KubebenchImage != "" || policy.Spec.Inspector.RiskImage != "" {
+		datasource, err := r.EnsureSettings(ctx, policy)
+		if err != nil {
+			log.Error(err, "unable to ensure the settings in inspection policy")
+			return ctrl.Result{}, err
+		}
+		log.Info("Ensure settings in inspection policy", "datasource in settings", datasource)
 	}
-	log.Info("Ensure settings in inspection policy", "datasource in settings", datasource)
 
 	// Ensure RBAC is correctly configured.
 	if err := r.ensureRBAC(ctx, *wns); err != nil {

--- a/src/pkg/inspectors/workloadscanner/pkg/controller.go
+++ b/src/pkg/inspectors/workloadscanner/pkg/controller.go
@@ -84,7 +84,7 @@ func (c *controller) Run(ctx context.Context, policy *v1alpha1.InspectionPolicy)
 	// Just in case.
 	if len(nsl) == 0 {
 		log.Info("no namespaces found")
-		ExportImageReports(itypes.WorkloadReport{}, policy)
+		ExportWorkloadsReports(itypes.WorkloadReport{}, policy)
 		return nil
 	}
 
@@ -161,12 +161,12 @@ func (c *controller) Run(ctx context.Context, policy *v1alpha1.InspectionPolicy)
 		return err
 	}
 
-	ExportImageReports(report, policy)
+	ExportWorkloadsReports(report, policy)
 
 	return nil
 }
 
-func ExportImageReports(report itypes.WorkloadReport, pl *v1alpha1.InspectionPolicy) {
+func ExportWorkloadsReports(report itypes.WorkloadReport, pl *v1alpha1.InspectionPolicy) {
 	log.Debugf("Sending workload infos to exporter: %v", report)
 
 	if bytes, err := json.Marshal(report); err != nil {

--- a/src/tools/installation/yaml/manager.yaml
+++ b/src/tools/installation/yaml/manager.yaml
@@ -349,6 +349,7 @@ spec:
                     format: int32
                     type: integer
                   suspend:
+                    default: false
                     description: Suspend the subsequent inspections temporarily.
                     type: boolean
                 type: object

--- a/src/tools/installation/yaml/manager.yaml
+++ b/src/tools/installation/yaml/manager.yaml
@@ -331,6 +331,8 @@ spec:
                   DataSource is the data source definitions.'
                 type: string
               strategy:
+                default:
+                  suspend: false
                 description: Strategy of the inspector.
                 properties:
                   concurrencyRule:
@@ -349,7 +351,6 @@ spec:
                     format: int32
                     type: integer
                   suspend:
-                    default: false
                     description: Suspend the subsequent inspections temporarily.
                     type: boolean
                 type: object


### PR DESCRIPTION

## Description
settingName and strategy as optional were not handled in controller manager while creating workloadscanner.
## Tests
### Before fix
<img width="692" alt="Screenshot 2023-03-20 at 5 02 09 PM" src="https://user-images.githubusercontent.com/122356562/226327447-96993dc4-d688-4778-9358-4ed5a7659dea.png">

### After fix
<img width="616" alt="Screenshot 2023-03-20 at 5 01 26 PM" src="https://user-images.githubusercontent.com/122356562/226327347-720770d6-edff-4382-a7c0-c1a711017727.png">
