### PR TITLE
BEGONIA-135: Include NewerBranchesAvailable property in VAC product info

### DIFF
--- a/cnsi-inspector/pkg/assets/workload/workload.go
+++ b/cnsi-inspector/pkg/assets/workload/workload.go
@@ -103,9 +103,11 @@ type VacProductInfo struct {
 	// The date-time which the product was released at
 	ReleasedAt *time.Time `json:"releasedAt,omitempty"`
 	// Last release version of product
-	LastVersionReleased *string            `json:"lastVersionReleased,omitempty"`
-	DeprecationPolicy   *DeprecationPolicy `json:"deprecationPolicy,omitempty"`
-	NonsupportPolicy    *NonSupportPolicy  `json:"nonSupportPolicy,omitempty"`
+	LastVersionReleased *string `json:"lastVersionReleased,omitempty"`
+	// Newer branches available for product
+	NewerBranchesAvailable []string           `json:"newerBranchesAvailable,omitempty"`
+	DeprecationPolicy      *DeprecationPolicy `json:"deprecationPolicy,omitempty"`
+	NonsupportPolicy       *NonSupportPolicy  `json:"nonSupportPolicy,omitempty"`
 	// The status of the product in the catalog. Available values are DRAFT, ACTIVE, SCHEDULED_DEPRECATION, DEPRECATION_GRACE_PERIOD, DEPRECATED, NON_SUPPORTED
 	Status *string `json:"status,omitempty"`
 }

--- a/cnsi-inspector/pkg/image-scanner/controller.go
+++ b/cnsi-inspector/pkg/image-scanner/controller.go
@@ -163,6 +163,7 @@ func (c *controller) convertProductToVacProductInfo(product *governor_client.Pro
 	vacProductInfo.Revision = product.Revision
 	vacProductInfo.ReleasedAt = &product.ReleasedAt
 	vacProductInfo.LastVersionReleased = product.LastVersionReleased
+	vacProductInfo.NewerBranchesAvailable = product.NewerBranchesAvailable
 	vacProductInfo.Status = product.Status
 
 	if product.DeprecationPolicy != nil {

--- a/lib/governor/go-client/model_product.go
+++ b/lib/governor/go-client/model_product.go
@@ -29,9 +29,11 @@ type Product struct {
 	// The date-time which the product was released at
 	ReleasedAt time.Time `json:"released_at"`
 	// Last release version of product
-	LastVersionReleased *string            `json:"last_version_released,omitempty"`
-	DeprecationPolicy   *DeprecationPolicy `json:"deprecation_policy,omitempty"`
-	NonsupportPolicy    *NonSupportPolicy  `json:"nonsupport_policy,omitempty"`
+	LastVersionReleased *string `json:"last_version_released,omitempty"`
+	// List of newer branches available for the product
+	NewerBranchesAvailable []string           `json:"newer_branches_available,omitempty"`
+	DeprecationPolicy      *DeprecationPolicy `json:"deprecation_policy,omitempty"`
+	NonsupportPolicy       *NonSupportPolicy  `json:"nonsupport_policy,omitempty"`
 	// The status of the product in the catalog. Available values are DRAFT, ACTIVE, SCHEDULED_DEPRECATION, DEPRECATION_GRACE_PERIOD, DEPRECATED, NON_SUPPORTED
 	Status               *string `json:"status,omitempty"`
 	AdditionalProperties map[string]interface{}
@@ -220,6 +222,38 @@ func (o *Product) SetLastVersionReleased(v string) {
 	o.LastVersionReleased = &v
 }
 
+// GetNewerBranchesAvailable returns the NewerBranchesAvailable field value if set, zero value otherwise.
+func (o *Product) GetNewerBranchesAvailable() []string {
+	if o == nil || o.NewerBranchesAvailable == nil {
+		var ret []string
+		return ret
+	}
+	return o.NewerBranchesAvailable
+}
+
+// GetNewerBranchesAvailableOk returns a tuple with the NewerBranchesAvailable field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Product) GetNewerBranchesAvailableOk() ([]string, bool) {
+	if o == nil || o.NewerBranchesAvailable == nil {
+		return nil, false
+	}
+	return o.NewerBranchesAvailable, true
+}
+
+// HasNewerBranchesAvailable returns a boolean if a field has been set.
+func (o *Product) HasNewerBranchesAvailable() bool {
+	if o != nil && o.NewerBranchesAvailable != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetNewerBranchesAvailable gets a reference to the given []string and assigns it to the NewerBranchesAvailable field.
+func (o *Product) SetNewerBranchesAvailable(v []string) {
+	o.NewerBranchesAvailable = v
+}
+
 // GetDeprecationPolicy returns the DeprecationPolicy field value if set, zero value otherwise.
 func (o *Product) GetDeprecationPolicy() DeprecationPolicy {
 	if o == nil || o.DeprecationPolicy == nil {
@@ -336,6 +370,9 @@ func (o Product) MarshalJSON() ([]byte, error) {
 	if o.LastVersionReleased != nil {
 		toSerialize["last_version_released"] = o.LastVersionReleased
 	}
+	if o.NewerBranchesAvailable != nil {
+		toSerialize["newer_branches_available"] = o.NewerBranchesAvailable
+	}
 	if o.DeprecationPolicy != nil {
 		toSerialize["deprecation_policy"] = o.DeprecationPolicy
 	}
@@ -369,6 +406,7 @@ func (o *Product) UnmarshalJSON(bytes []byte) (err error) {
 		delete(additionalProperties, "revision")
 		delete(additionalProperties, "released_at")
 		delete(additionalProperties, "last_version_released")
+		delete(additionalProperties, "newer_branches_available")
 		delete(additionalProperties, "deprecation_policy")
 		delete(additionalProperties, "nonsupport_policy")
 		delete(additionalProperties, "status")


### PR DESCRIPTION
Fixes ISSUE 
Adding NewerBranchesAvailable property under VAC product info in a container

## Description
Adding NewerBranchesAvailable property under VAC product info in a container

## Tests
### Before fix
```
"vacAssessment":{
                                             "trusted":true,
                                             "name":"Apache",
                                             "branch":"2.4",
                                             "version":"2.4.56",
                                             "revision":"22",
                                             "releasedAt":"2023-03-31T16:13:25Z",
                                             "lastVersionReleased":"2.4.57-r7",
                                             "status":"ACTIVE"
                                          }
```
### After fix
```
"vacAssessment": {
                                  "trusted": true,
                                  "name": "NGINX Open Source",
                                  "branch": "1.22",
                                  "version": "1.22.1",
                                  "revision": "164",
                                  "releasedAt": "2023-04-13T10:00:44Z",
                                  "lastVersionReleased": "1.22.1-r164",
                                  "newerBranchesAvailable": [
                                       "1.23"
                                  ],
                                  "status": "ACTIVE"
},
```